### PR TITLE
Restrict SSE tick for ledger changes only

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -257,9 +257,8 @@ func (a *App) Tick() {
 	go func() { a.submitter.Tick(a.ctx); wg.Done() }()
 	wg.Wait()
 
+	// Execute SSE only if there were in changes to ledger or history
 	newLedgerState := ledger.CurrentState()
-
-	// Run sse only if changes in history happend
 	if newLedgerState.CoreLatest > initialLedgerState.CoreLatest ||
 		newLedgerState.HistoryLatest > initialLedgerState.HistoryLatest {
 		sse.Tick()


### PR DESCRIPTION
In order to optimize horizon<->DB throughput, avoid running sse procedures if
no change happen in ledger state.