### PR TITLE
increase horizon sse hello event retry time to 60s from 1s

### DIFF
--- a/services/horizon/internal/render/sse/main.go
+++ b/services/horizon/internal/render/sse/main.go
@@ -116,7 +116,7 @@ var goodbyeEvent = Event{
 var helloEvent = Event{
 	Data:  "hello",
 	Event: "open",
-	Retry: 1000,
+	Retry: 60000,
 }
 
 var lock sync.Mutex


### PR DESCRIPTION
this should lower the sse spam load on horizons