### PR TITLE
Send initial reply right after client connection

### DIFF
--- a/services/horizon/internal/actions/base.go
+++ b/services/horizon/internal/actions/base.go
@@ -64,6 +64,7 @@ func (base *Base) Execute(action interface{}) {
 		}
 
 		stream := sse.NewStream(base.Ctx, base.W, base.R)
+		sse.WritePreamble(base.Ctx, base.W)
 
 		for {
 			action.SSE(stream)


### PR DESCRIPTION
Using this method client will use reply interval even if it didn't received any event yet