### PR TITLE
lower horizon sse hello event retry time to 5s from 60s

### DIFF
--- a/services/horizon/internal/render/sse/main.go
+++ b/services/horizon/internal/render/sse/main.go
@@ -116,7 +116,7 @@ var goodbyeEvent = Event{
 var helloEvent = Event{
 	Data:  "hello",
 	Event: "open",
-	Retry: 60000,
+	Retry: 5000,
 }
 
 var lock sync.Mutex


### PR DESCRIPTION
hurting user onboarding flow when waiting for an account to be created