### PR TITLE
bring back hitting the db only when new ledger is added (previous pr)

### DIFF
--- a/services/horizon/internal/app.go
+++ b/services/horizon/internal/app.go
@@ -239,6 +239,10 @@ func (a *App) Tick() {
 	var wg sync.WaitGroup
 	log.Debug("ticking app")
 	// update ledger state and stellar-core info in parallel
+
+	// Getting current ledger as reference, to avoid running sse tick in case of no ledger change
+	initialLedgerState := ledger.CurrentState()
+
 	wg.Add(2)
 	go func() { a.UpdateLedgerState(); wg.Done() }()
 	go func() { a.UpdateStellarCoreInfo(); wg.Done() }()
@@ -253,7 +257,12 @@ func (a *App) Tick() {
 	go func() { a.submitter.Tick(a.ctx); wg.Done() }()
 	wg.Wait()
 
-	sse.Tick()
+	// Execute SSE only if there were in changes to ledger or history
+	newLedgerState := ledger.CurrentState()
+	if newLedgerState.CoreLatest > initialLedgerState.CoreLatest ||
+		newLedgerState.HistoryLatest > initialLedgerState.HistoryLatest {
+		sse.Tick()
+	}
 
 	// finally, update metrics
 	a.UpdateMetrics()


### PR DESCRIPTION
This reverts commit 21fe0903eadaca0be94977d982324c68a7dd794a, reversing
changes made to 7e7703e868027740217e228e30494ff8b00e2110.

reverted this by mistake. we're bringing this feature back