### PR TITLE
Publish to pubsub on non-block mode

### DIFF
--- a/services/horizon/internal/ingest/ingestion.go
+++ b/services/horizon/internal/ingest/ingestion.go
@@ -518,7 +518,7 @@ func (ingest *Ingestion) commit() error {
 		return err
 	}
 	// Update subscribers that commit is done to the DB.
-	commitPubsub.Pub(pubsubStubValue, pubsubCommitTopic)
+	commitPubsub.TryPub(pubsubStubValue, pubsubCommitTopic)
 	return nil
 }
 


### PR DESCRIPTION
This is a potential bug that might stuck the server in case of capacity issues for the channel. Using non-blocking method resolves this.