### PR TITLE
Support custom cursor name for horizon

### DIFF
--- a/services/horizon/db.go
+++ b/services/horizon/db.go
@@ -228,7 +228,7 @@ func ingestSystem() *ingest.System {
 		log.Fatal("network-passphrase is blank: reingestion requires manually setting passphrase")
 	}
 
-	i := ingest.New(passphrase, config.StellarCoreURL, cdb, hdb)
+	i := ingest.New(passphrase, config.StellarCoreURL, cdb, hdb, config.CursorName)
 	return i
 }
 

--- a/services/horizon/internal/config.go
+++ b/services/horizon/internal/config.go
@@ -26,6 +26,9 @@ type Config struct {
 	// Ingest is a boolean that indicates whether or not this horizon instance
 	// should run the data ingestion subsystem.
 	Ingest bool
+	// CursorName indentifying horizon cursor, so multiple horizons will be able
+	// to communicate with a single core without collisions in cursor info
+	CursorName string
 	// HistoryRetentionCount represents the minimum number of ledgers worth of
 	// history data to retain in the horizon database. For the purposes of
 	// determining a "retention duration", each ledger roughly corresponds to 10

--- a/services/horizon/internal/ingest/main.go
+++ b/services/horizon/internal/ingest/main.go
@@ -59,6 +59,8 @@ type Cursor struct {
 
 	// Err is the error that caused this iteration to fail, if any.
 	Err error
+	// Name is unique identifier tracking of latest ingest on stellar-core
+	Name string
 
 	lg   int32
 	tx   int
@@ -103,6 +105,10 @@ type System struct {
 	// StellarCoreURL is the http endpoint of the stellar-core that data is being
 	// ingested from.
 	StellarCoreURL string
+
+	// CursorName is the identifier of this horizon instance for tracking cursor data
+	// in stellar-core
+	CursorName string
 
 	// SkipCursorUpdate causes the ingestor to skip
 	// reporting the "last imported ledger" cursor to
@@ -185,12 +191,13 @@ type Session struct {
 
 // New initializes the ingester, causing it to begin polling the stellar-core
 // database for now ledgers and ingesting data into the horizon database.
-func New(network string, coreURL string, core, horizon *db.Session) *System {
+func New(network string, coreURL string, core, horizon *db.Session, cursorName string) *System {
 	i := &System{
 		Network:        network,
 		StellarCoreURL: coreURL,
 		HorizonDB:      horizon,
 		CoreDB:         core,
+		CursorName:     cursorName,
 	}
 
 	i.Metrics.ClearLedgerTimer = metrics.NewTimer()
@@ -205,6 +212,7 @@ func NewCursor(first, last int32, i *System) *Cursor {
 		FirstLedger:    first,
 		LastLedger:     last,
 		CoreDB:         i.CoreDB,
+		Name:           i.CursorName,
 		Metrics:        &i.Metrics,
 		AssetsModified: AssetsModified(make(map[string]xdr.Asset)),
 	}

--- a/services/horizon/internal/ingest/main_test.go
+++ b/services/horizon/internal/ingest/main_test.go
@@ -60,5 +60,6 @@ func sys(tt *test.T) *System {
 		"",
 		tt.CoreSession(),
 		tt.HorizonSession(),
+		"HORIZON",
 	)
 }

--- a/services/horizon/internal/ingest/session.go
+++ b/services/horizon/internal/ingest/session.go
@@ -786,7 +786,7 @@ func (is *Session) reportCursorState() error {
 
 	core := &stellarcore.Client{URL: is.StellarCoreURL}
 
-	err := core.SetCursor(context.Background(), "HORIZON", is.Cursor.LastLedger)
+	err := core.SetCursor(context.Background(), is.Cursor.Name, is.Cursor.LastLedger)
 
 	if err != nil {
 		return errors.Wrap(err, "SetCursor failed")

--- a/services/horizon/internal/ingest/system_test.go
+++ b/services/horizon/internal/ingest/system_test.go
@@ -51,7 +51,7 @@ func TestValidation(t *testing.T) {
 	tt := test.Start(t).Scenario("kahuna")
 	defer tt.Finish()
 
-	sys := New(network.TestNetworkPassphrase, "", tt.CoreSession(), tt.HorizonSession())
+	sys := New(network.TestNetworkPassphrase, "", tt.CoreSession(), tt.HorizonSession(), "HORIZON")
 
 	// intact chain
 	for i := int32(2); i <= 57; i++ {

--- a/services/horizon/internal/init_ingester.go
+++ b/services/horizon/internal/init_ingester.go
@@ -20,6 +20,7 @@ func initIngester(app *App) {
 		app.config.StellarCoreURL,
 		app.CoreSession(nil),
 		app.HorizonSession(nil),
+		app.config.CursorName,
 	)
 
 	app.ingester.SkipCursorUpdate = app.config.SkipCursorUpdate

--- a/services/horizon/internal/sse_test.go
+++ b/services/horizon/internal/sse_test.go
@@ -189,5 +189,6 @@ func sys(tt *test.T) *ingest.System {
 		"",
 		tt.CoreSession(),
 		tt.HorizonSession(),
+		"HORIZON",
 	)
 }

--- a/services/horizon/main.go
+++ b/services/horizon/main.go
@@ -29,6 +29,7 @@ func init() {
 	viper.SetDefault("horizon-db-max-idle-connections", 4)
 	viper.SetDefault("core-db-max-open-connections", 12)
 	viper.SetDefault("core-db-max-idle-connections", 4)
+	viper.SetDefault("cursor-name", "HORIZON")
 
 	viper.BindEnv("port", "PORT")
 	viper.BindEnv("db-url", "DATABASE_URL")
@@ -45,6 +46,7 @@ func init() {
 	viper.BindEnv("tls-cert", "TLS_CERT")
 	viper.BindEnv("tls-key", "TLS_KEY")
 	viper.BindEnv("ingest", "INGEST")
+	viper.BindEnv("cursor-name", "CURSOR_NAME")
 	viper.BindEnv("network-passphrase", "NETWORK_PASSPHRASE")
 	viper.BindEnv("history-retention-count", "HISTORY_RETENTION_COUNT")
 	viper.BindEnv("history-stale-threshold", "HISTORY_STALE_THRESHOLD")
@@ -149,6 +151,12 @@ func init() {
 	)
 
 	rootCmd.PersistentFlags().String(
+		"cursor-name",
+		"",
+		"Override the cursor name used in stellar-core",
+	)
+
+	rootCmd.PersistentFlags().String(
 		"network-passphrase",
 		"",
 		"Override the network passphrase",
@@ -227,6 +235,7 @@ func initConfig() {
 		TLSCert:                     cert,
 		TLSKey:                      key,
 		Ingest:                      viper.GetBool("ingest"),
+		CursorName:                  viper.GetString("cursor-name"),
 		HistoryRetentionCount:       uint(viper.GetInt("history-retention-count")),
 		StaleThreshold:              uint(viper.GetInt("history-stale-threshold")),
 		SkipCursorUpdate:            viper.GetBool("skip-cursor-update"),


### PR DESCRIPTION
Whenever horizon ingests from stellar-core, an entry is updated regarding current location. This way, several horizon servers can perform ingest from a single stellar-core.
