### PR TITLE
Fix references to kinecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-# Stellar Go 
-[![Build Status](https://travis-ci.org/stellar/go.svg?branch=master)](https://travis-ci.org/stellar/go) 
-[![GoDoc](https://godoc.org/github.com/stellar/go?status.svg)](https://godoc.org/github.com/stellar/go)
-[![Go Report Card](https://goreportcard.com/badge/github.com/stellar/go)](https://goreportcard.com/report/github.com/stellar/go)
+# Kin Go
+[![GoDoc](https://godoc.org/github.com/kinecosystem/go?status.svg)](https://godoc.org/github.com/kinecosystem/go)
+[![Go Report Card](https://goreportcard.com/badge/github.com/kinecosystem/go)](https://goreportcard.com/report/github.com/kinecosystem/go)
 
 This repo is the home for all of the public go code produced by SDF.  In addition to various tools and services, this repository is the SDK from which you may develop your own applications that integrate with the stellar network.
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 [![GoDoc](https://godoc.org/github.com/kinecosystem/go?status.svg)](https://godoc.org/github.com/kinecosystem/go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kinecosystem/go)](https://goreportcard.com/report/github.com/kinecosystem/go)
 
-This repo is the home for all of the public go code produced by SDF.  In addition to various tools and services, this repository is the SDK from which you may develop your own applications that integrate with the stellar network.
+This repo is the home for all of the public go code produced by the Kin Foundation.  In addition to various tools and services, this repository is the SDK from which you may develop your own applications that integrate with the Kin network.
 
 ## Package Index
 
-* [Horizon Server](services/horizon): Full-featured API server for Stellar network
+* [Horizon Server](services/horizon): Full-featured API server for Kin network
 * [Go Clients (Horizon SDK)](clients): Go SDK for making requests to Horizon Server
 
 ## Dependencies
@@ -21,7 +21,7 @@ $ dep ensure -v
 
 Note that if this hangs indefinitely on your machine, you might need to check if mercurial is installed.
 
-You can use dep yourself in your project and add stellar go as a vendor'd dependency, or you can just drop this repos as `$GOPATH/src/github.com/stellar/go` to import it the canonical way (you still need to run `dep ensure -v`).
+You can use dep yourself in your project and add Kin go as a vendor'd dependency, or you can just drop this repos as `$GOPATH/src/github.com/kinecosystem/go` to import it the canonical way (you still need to run `dep ensure -v`).
 
 When creating this project, we had to decide whether or not we committed our external dependencies to the repo.  We decided that we would not, by default, do so.  This lets us avoid the diff churn associated with updating dependencies while allowing an acceptable path to get reproducible builds.  To do so, simply install dep and run `dep ensure -v` in your checkout of the code.  We realize this is a judgement call; Please feel free to open an issue if you would like to make a case that we change this policy.
 
@@ -29,10 +29,10 @@ When creating this project, we had to decide whether or not we committed our ext
 
 In addition to the other top-level packages, there are a few special directories that contain specific types of packages:
 
-* **clients** contains packages that provide client packages to the various Stellar services.
+* **clients** contains packages that provide client packages to the various Kin services.
 * **exp** contains experimental packages.  Use at your own risk.
-* **handlers** contains packages that provide pluggable implementors of `http.Handler` that make it easier to incorporate portions of the Stellar protocol into your own http server. 
-* **support** contains packages that are not intended for consumption outside of Stellar's other packages.  Packages that provide common infrastructure for use in our services and tools should go here, such as `db` or `log`. 
+* **handlers** contains packages that provide pluggable implementors of `http.Handler` that make it easier to incorporate portions of the Kin protocol into your own http server. 
+* **support** contains packages that are not intended for consumption outside of Kin's other packages.  Packages that provide common infrastructure for use in our services and tools should go here, such as `db` or `log`. 
 * **support/scripts** contains single-file go programs and bash scripts used to support the development of this repo. 
 * **services** contains packages that compile to applications that are long-running processes (such as API servers).
 * **tools** contains packages that compile to command line applications.
@@ -41,7 +41,7 @@ Each of these directories have their own README file that explain further the na
 
 ### Other packages
 
-In addition to the packages described above, this repository contains various packages related to working with the Stellar network from a go program.  It's recommended that you use [godoc](https://godoc.org/github.com/stellar/go#pkg-subdirectories) to browse the documentation for each.
+In addition to the packages described above, this repository contains various packages related to working with the Kin network from a go program.  It's recommended that you use [godoc](https://godoc.org/github.com/kinecosystem/go#pkg-subdirectories) to browse the documentation for each.
 
 
 ## Package source layout

--- a/clients/README.md
+++ b/clients/README.md
@@ -1,8 +1,8 @@
 # Clients package
 
-Packages contained by this package provide client libraries for accessing the ecosystem of stellar services.  At present, it only contains a simple horizon client library, but in the future it will contain clients to interact with stellar-core, federation, the bridge server and more.
+Packages contained by this package provide client libraries for accessing the ecosystem of Kin services.  At present, it only contains a simple horizon client library, but in the future it will contain clients to interact with core, and more.
 
-See [godoc](https://godoc.org/github.com/stellar/go/clients) for details about each package.
+See [godoc](https://godoc.org/github.com/kinecosystem/go/clients) for details about each package.
 
 ## Adding new client packages
 

--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -7,7 +7,7 @@ title: Basic Examples
 
 ## Creating and submitting a payment transaction
 
-Crafting transactions and getting the base64-encoded transaction envelope (often referred to as the "transaction blob") is a central aspect of interacting with the stellar network.  The Go SDK uses the `build` package to craft transactions.  The example below builds a payment for testnet and outputs the encoded blob to standard out.  For this example, we have two previously created accounts on the test network.
+Crafting transactions and getting the base64-encoded transaction envelope (often referred to as the "transaction blob") is a central aspect of interacting with the Kin network.  The Go SDK uses the `build` package to craft transactions.  The example below builds a payment for testnet and outputs the encoded blob to standard out.  For this example, we have two previously created accounts on the test network.
 
 ```go
 package main
@@ -15,8 +15,8 @@ package main
 import (
 	"fmt"
 
-	b "github.com/stellar/go/build"
-	"github.com/stellar/go/clients/horizon"
+	b "github.com/kinecosystem/go/build"
+	"github.com/kinecosystem/go/clients/horizon"
 )
 
 func main() {
@@ -64,7 +64,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/stellar/go/clients/horizon"
+	"github.com/kinecosystem/go/clients/horizon"
 )
 
 func main() {

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -2,16 +2,16 @@
 title: Overview
 ---
 
-The Go SDK contains packages for interacting with most aspects of the stellar ecosystem.  In addition to generally useful, low-level packages such as [`keypair`](https://godoc.org/github.com/stellar/go/keypair) (used for creating stellar-compliant public/secret key pairs), the Go SDK also contains code for the server applications and client tools written in go.
+The Go SDK contains packages for interacting with most aspects of the Kin ecosystem.  In addition to generally useful, low-level packages such as [`keypair`](https://godoc.org/github.com/kinecosystem/go/keypair) (used for creating Kin-compliant public/secret key pairs), the Go SDK also contains code for the server applications and client tools written in go.
 
 ## Godoc reference
 
-The most accurate and up-to-date reference information on the Go SDK is found within godoc.  The godoc.org service automatically updates the documentation for the Go SDK everytime github is updated.  The godoc for all of our packages can be found at (https://godoc.org/github.com/stellar/go).
+The most accurate and up-to-date reference information on the Go SDK is found within godoc.  The godoc.org service automatically updates the documentation for the Go SDK everytime github is updated.  The godoc for all of our packages can be found at (https://godoc.org/github.com/kinecosystem/go).
 
 ## Client Packages
 
-The Go SDK contains packages for interacting with the various stellar services:
+The Go SDK contains packages for interacting with the various Kin services:
 
-- [`horizon`](https://godoc.org/github.com/stellar/go/clients/horizon) provides client access to a horizon server, allowing you to load account information, stream payments, post transactions and more.
-- [`stellartoml`](https://godoc.org/github.com/stellar/go/clients/stellartoml) provides the ability to resolve Stellar.toml files from the internet.  You can read about [Stellar.toml concepts here](../../guides/concepts/stellar-toml.md).
+- [`horizon`](https://godoc.org/github.com/kinecosystem/go/clients/horizon) provides client access to a horizon server, allowing you to load account information, stream payments, post transactions and more.
+- [`stellartoml`](https://godoc.org/github.com/kinecosystem/go/clients/stellartoml) provides the ability to resolve Stellar.toml files from the internet.  You can read about [Stellar.toml concepts here](../../guides/concepts/stellar-toml.md).
 

--- a/exp/README.me
+++ b/exp/README.me
@@ -2,8 +2,8 @@
 
 Packages contained within this folder are considered experimental, and may be buggy or broken.  This provides a location where developers can experiment with new APIs, 
 
-See [godoc](https://godoc.org/github.com/stellar/go/exp) for details about each package.
+See [godoc](https://godoc.org/github.com/kinecosystem/go/exp) for details about each package.
 
 ## Adding experimental services, clients, tools, etc.
 
-Just as with the non-experimental portion of this repo, the `exp` package uses a well-defined package structure for a few common activities.  An experimental service would go in `github.com/stellar/go/exp/services`, for example.
+Just as with the non-experimental portion of this repo, the `exp` package uses a well-defined package structure for a few common activities.  An experimental service would go in `github.com/kinecosystem/go/exp/services`, for example.

--- a/services/README.md
+++ b/services/README.md
@@ -2,4 +2,4 @@
 
 Packages contained by this package represent the long-running applications developed for the Stellar network.
 
-See [godoc](https://godoc.org/github.com/stellar/go/services) for details about each application.
+See [godoc](https://godoc.org/github.com/kinecosystem/go/services) for details about each application.

--- a/services/horizon/README.md
+++ b/services/horizon/README.md
@@ -1,13 +1,12 @@
 # Horizon
-[![Build Status](https://travis-ci.org/stellar/go.svg?branch=master)](https://travis-ci.org/stellar/go)
 
-Horizon is the client facing API server for the [Stellar ecosystem](https://www.stellar.org/developers/guides/get-started/).  It acts as the interface between [Stellar Core](https://www.stellar.org/developers/stellar-core/software/admin.html) and applications that want to access the Stellar network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams and more.
+Horizon is the client facing API server for the Kin ecosystem.  It acts as the interface between [Core](https://www.stellar.org/developers/stellar-core/software/admin.html) and applications that want to access the Kin network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams and more.
 
 ## Try it out
-See Horizon in action by running your own Stellar node as part of the Stellar [testnet](https://www.stellar.org/developers/guides/concepts/test-net.html). With our Docker quick-start image, you can be running your own fully functional node in around 20 minutes. See the [Quickstart Guide](internal/docs/quickstart.md) to get up and running.
+See Horizon in action by running your own Kin node as part of the Kin [testnet](https://www.stellar.org/developers/guides/concepts/test-net.html). With our Docker quick-start image, you can be running your own fully functional node in around 20 minutes. See the [Quickstart Guide](internal/docs/quickstart.md) to get up and running.
 
 ## Run a production server
-If you're an administrator planning to run a production instance of Horizon as part of the public Stellar network, check out the detailed [Administration Guide](internal/docs/admin.md). It covers installation, monitoring, error scenarios and more.
+If you're an administrator planning to run a production instance of Horizon as part of the public Kin network, check out the detailed [Administration Guide](internal/docs/admin.md). It covers installation, monitoring, error scenarios and more.
 
 ## Contributing
 As an open source project, development of Horizon is public, and you can help! We welcome new issue reports, documentation and bug fixes, and contributions that further the project roadmap. The [Development Guide](internal/docs/developing.md) will show you how to build Horizon, see what's going on behind the scenes, and set up an effective develop-test-push cycle so that you can get your work incorporated quickly.

--- a/services/horizon/internal/docs/admin.md
+++ b/services/horizon/internal/docs/admin.md
@@ -3,28 +3,28 @@ title: Horizon Administration Guide
 ---
 ## Horizon Administration Guide
 
-Horizon is responsible for providing an HTTP API to data in the Stellar network. It ingests and re-serves the data produced by the stellar network in a form that is easier to consume than the performance-oriented data representations used by stellar-core.
+Horizon is responsible for providing an HTTP API to data in the Kin network. It ingests and re-serves the data produced by the Kin network in a form that is easier to consume than the performance-oriented data representations used by core.
 
 This document describes how to administer a **production** Horizon instance. If you are just starting with Horizon and want to try it out, consider the [Quickstart Guide](quickstart.md) instead. For information about developing on the Horizon codebase, check out the [Development Guide](developing.md).
 
 ## Why run Horizon?
 
-The Stellar Development Foundation runs two Horizon servers, one for the public network and one for the test network, free for anyone's use at https://horizon.stellar.org and https://horizon-testnet.stellar.org.  These servers should be fine for development and small scale projects, but it is not recommended that you use them for production services that need strong reliability.  By running Horizon within your own infrastructure provides a number of benefits:
+The Kin Foundation runs two Horizon servers, one for the public network and one for the test network, free for anyone's use at https://horizon.kinfederation.com and https://horizon-testnet.kinfederation.com .  These servers should be fine for development and small scale projects, but it is not recommended that you use them for production services that need strong reliability.  By running Horizon within your own infrastructure provides a number of benefits:
 
   - Multiple instances can be run for redundancy and scalability.
   - Request rate limiting can be disabled.
-  - Full operational control without dependency on the Stellar Development Foundations operations.
+  - Full operational control without dependency on the Kin Foundation's operations.
 
 ## Prerequisites
 
-Horizon is dependent upon a stellar-core server.  Horizon needs access to both the SQL database and the HTTP API that is published by stellar-core. See [the administration guide](https://www.stellar.org/developers/stellar-core/learn/admin.html
-) to learn how to set up and administer a stellar-core server.  Secondly, Horizon is dependent upon a postgres server, which it uses to store processed core data for ease of use. Horizon requires postgres version >= 9.3.
+Horizon is dependent upon a Core server.  Horizon needs access to both the SQL database and the HTTP API that is published by Core. See [the administration guide](https://www.stellar.org/developers/stellar-core/learn/admin.html
+) to learn how to set up and administer a core server.  Secondly, Horizon is dependent upon a postgres server, which it uses to store processed core data for ease of use. Horizon requires postgres version >= 9.3.
 
 In addition to the two prerequisites above, you may optionally install a redis server to be used for rate limiting requests.
 
 ## Installing
 
-To install Horizon, you have a choice: either downloading a [prebuilt release for your target architecture](https://github.com/stellar/go/releases) and operation system, or [building Horizon yourself](#Building).  When either approach is complete, you will find yourself with a directory containing a file named `horizon`.  This file is a native binary.
+To install Horizon, you have a choice: either downloading a [prebuilt release for your target architecture](https://github.com/kinecosystem/go/releases) and operation system, or [building Horizon yourself](#Building).  When either approach is complete, you will find yourself with a directory containing a file named `horizon`.  This file is a native binary.
 
 After building or unpacking Horizon, you simply need to copy the native binary into a directory that is part of your PATH.  Most unix-like systems have `/usr/local/bin` in PATH by default, so unless you have a preference or know better, we recommend you copy the binary there.
 
@@ -43,9 +43,9 @@ Should you decide not to use one of our prebuilt releases, you may instead build
 
 
 1. Set your [GOPATH](https://github.com/golang/go/wiki/GOPATH) environment variable, if you haven't already. The default `GOPATH` is `$HOME/go`.
-2. Clone the Stellar Go monorepo:  `go get github.com/stellar/go`. You should see the repository cloned at `$GOPATH/src/github.com/stellar/go`.
-3. Enter the source dir: `cd $GOPATH/src/github.com/stellar/go`, and download external dependencies: `dep ensure -v`. You should see the downloaded third party dependencies in `$GOPATH/pkg`.
-4. Compile the Horizon binary: `cd $GOPATH; go install github.com/stellar/go/services/horizon`. You should see the `horizon` binary in `$GOPATH/bin`.
+2. Clone the Kin Go monorepo:  `go get github.com/kinecosystem/go`. You should see the repository cloned at `$GOPATH/src/github.com/kinecosystem/go`.
+3. Enter the source dir: `cd $GOPATH/src/github.com/kinecosystem/go`, and download external dependencies: `dep ensure -v`. You should see the downloaded third party dependencies in `$GOPATH/pkg`.
+4. Compile the Horizon binary: `cd $GOPATH; go install github.com/kinecosystem/go/services/horizon`. You should see the `horizon` binary in `$GOPATH/bin`.
 5. Add Go binaries to your PATH in your `bashrc` or equivalent, for easy access: `export PATH=${GOPATH//://bin:}/bin:$PATH`
 
 Open a new terminal. Confirm everything worked by running `horizon --help` successfully.
@@ -67,15 +67,15 @@ As you will see if you run the command above, Horizon defines a large number of 
 | `--stellar-core-db-url` | `STELLAR_CORE_DATABASE_URL` | postgres://localhost/core_testnet    |
 | `--stellar-core-url`    | `STELLAR_CORE_URL`          | http://localhost:11626               |
 
-`--db-url` specifies the Horizon database, and its value should be a valid [PostgreSQL Connection URI](http://www.postgresql.org/docs/9.2/static/libpq-connect.html#AEN38419).  `--stellar-core-db-url` specifies a stellar-core database which will be used to load data about the stellar ledger.  Finally, `--stellar-core-url` specifies the HTTP control port for an instance of stellar-core.  This URL should be associated with the stellar-core that is writing to the database at `--stellar-core-db-url`.
+`--db-url` specifies the Horizon database, and its value should be a valid [PostgreSQL Connection URI](http://www.postgresql.org/docs/9.2/static/libpq-connect.html#AEN38419).  `--stellar-core-db-url` specifies a core database which will be used to load data about the Kin ledger.  Finally, `--stellar-core-url` specifies the HTTP control port for an instance of core.  This URL should be associated with the core that is writing to the database at `--stellar-core-db-url`.
 
-Specifying command line flags every time you invoke Horizon can be cumbersome, and so we recommend using environment variables.  There are many tools you can use to manage environment variables:  we recommend either [direnv](http://direnv.net/) or [dotenv](https://github.com/bkeepers/dotenv).  A template configuration that is compatible with dotenv can be found in the [Horizon git repo](https://github.com/stellar/go/blob/master/services/horizon/.env.template).
+Specifying command line flags every time you invoke Horizon can be cumbersome, and so we recommend using environment variables.  There are many tools you can use to manage environment variables:  we recommend either [direnv](http://direnv.net/) or [dotenv](https://github.com/bkeepers/dotenv).  A template configuration that is compatible with dotenv can be found in the [Horizon git repo](https://github.com/kinecosystem/go/blob/master/services/horizon/.env.template).
 
 
 
 ## Preparing the database
 
-Before the Horizon server can be run, we must first prepare the Horizon database.  This database will be used for all of the information produced by Horizon, notably historical information about successful transactions that have occurred on the stellar network.  
+Before the Horizon server can be run, we must first prepare the Horizon database.  This database will be used for all of the information produced by Horizon, notably historical information about successful transactions that have occurred on the Kin network.  
 
 To prepare a database for Horizon's use, first you must ensure the database is blank.  It's easiest to simply create a new database on your postgres server specifically for Horizon's use.  Next you must install the schema by running `horizon db init`.  Remember to use the appropriate command line flags or environment variables to configure Horizon as explained in [Configuring ](#Configuring).  This command will log any errors that occur.
 
@@ -94,33 +94,33 @@ INFO[0000] Starting horizon on :8000                     pid=29013
 The log line above announces that Horizon is ready to serve client requests. Note: the numbers shown above may be different for your installation.  Next we can confirm that Horizon is responding correctly by loading the root resource.  In the example above, that URL would be [http://127.0.0.1:8000/] and simply running `curl http://127.0.0.1:8000/` shows you that the root resource can be loaded correctly.
 
 
-## Ingesting live stellar-core data
+## Ingesting live core data
 
-Horizon provides most of its utility through ingested data.  Your Horizon server can be configured to listen for and ingest transaction results from the connected stellar-core.  We recommend that within your infrastructure you run one (and only one) Horizon process that is configured in this way.   While running multiple ingestion processes will not corrupt the Horizon database, your error logs will quickly fill up as the two instances race to ingest the data from stellar-core.  We may develop a system that coordinates multiple Horizon processes in the future, but we would also be happy to include an external contribution that accomplishes this.
+Horizon provides most of its utility through ingested data.  Your Horizon server can be configured to listen for and ingest transaction results from the connected core.  We recommend that within your infrastructure you run one (and only one) Horizon process that is configured in this way.   While running multiple ingestion processes will not corrupt the Horizon database, your error logs will quickly fill up as the two instances race to ingest the data from core.  We may develop a system that coordinates multiple Horizon processes in the future, but we would also be happy to include an external contribution that accomplishes this.
 
 To enable ingestion, you must either pass `--ingest=true` on the command line or set the `INGEST` environment variable to "true".
 
 ### Ingesting historical data
 
-To enable ingestion of historical data from stellar-core you need to run `horizon db backfill NUM_LEDGERS`. If you're running a full validator with published history archive, for example, you might want to ingest all of history. In this case your `NUM_LEDGERS` should be slightly higher than the current ledger id on the network. You can run this process in the background while your Horizon server is up. This continuously decrements the `history.elder_ledger` in your /metrics endpoint until `NUM_LEDGERS` is reached and the backfill is complete. 
+To enable ingestion of historical data from core you need to run `horizon db backfill NUM_LEDGERS`. If you're running a full validator with published history archive, for example, you might want to ingest all of history. In this case your `NUM_LEDGERS` should be slightly higher than the current ledger id on the network. You can run this process in the background while your Horizon server is up. This continuously decrements the `history.elder_ledger` in your /metrics endpoint until `NUM_LEDGERS` is reached and the backfill is complete. 
 
 ### Managing storage for historical data
 
-Over time, the recorded network history will grow unbounded, increasing storage used by the database. Horizon expands the data ingested from stellar-core and needs sufficient disk space. Unless you need to maintain a history archive you may configure Horizon to only retain a certain number of ledgers in the database. This is done using the `--history-retention-count` flag or the `HISTORY_RETENTION_COUNT` environment variable. Set the value to the number of recent ledgers you wish to keep around, and every hour the Horizon subsystem will reap expired data.  Alternatively, you may execute the command `horizon db reap` to force a collection.
+Over time, the recorded network history will grow unbounded, increasing storage used by the database. Horizon expands the data ingested from core and needs sufficient disk space. Unless you need to maintain a history archive you may configure Horizon to only retain a certain number of ledgers in the database. This is done using the `--history-retention-count` flag or the `HISTORY_RETENTION_COUNT` environment variable. Set the value to the number of recent ledgers you wish to keep around, and every hour the Horizon subsystem will reap expired data.  Alternatively, you may execute the command `horizon db reap` to force a collection.
 
-### Surviving stellar-core downtime
+### Surviving core downtime
 
-Horizon tries to maintain a gap-free window into the history of the stellar-network.  This reduces the number of edge cases that Horizon-dependent software must deal with, aiming to make the integration process simpler.  To maintain a gap-free history, Horizon needs access to all of the metadata produced by stellar-core in the process of closing a ledger, and there are instances when this metadata can be lost.  Usually, this loss of metadata occurs because the stellar-core node went offline and performed a catchup operation when restarted.
+Horizon tries to maintain a gap-free window into the history of the Kin network.  This reduces the number of edge cases that Horizon-dependent software must deal with, aiming to make the integration process simpler.  To maintain a gap-free history, Horizon needs access to all of the metadata produced by core in the process of closing a ledger, and there are instances when this metadata can be lost.  Usually, this loss of metadata occurs because the core node went offline and performed a catchup operation when restarted.
 
-To ensure that the metadata required by Horizon is maintained, you have several options: You may either set the `CATCHUP_COMPLETE` stellar-core configuration option to `true` or configure `CATCHUP_RECENT` to determine the amount of time your stellar-core can be offline without having to rebuild your Horizon database.
+To ensure that the metadata required by Horizon is maintained, you have several options: You may either set the `CATCHUP_COMPLETE` core configuration option to `true` or configure `CATCHUP_RECENT` to determine the amount of time your core can be offline without having to rebuild your Horizon database.
 
-Unless your node is a full validator and archive publisher we _do not_ recommend using the `CATCHUP_COMPLETE` method, as this will force stellar-core to apply every transaction from the beginning of the ledger, which will take an ever increasing amount of time. Instead, we recommend you set the `CATCHUP_RECENT` config value. To do this, determine how long of a downtime you would like to survive (expressed in seconds) and divide by ten.  This roughly equates to the number of ledgers that occur within your desired grace period (ledgers roughly close at a rate of one every ten seconds).  With this value set, stellar-core will replay transactions for ledgers that are recent enough, ensuring that the metadata needed by Horizon is present.
+Unless your node is a full validator and archive publisher we _do not_ recommend using the `CATCHUP_COMPLETE` method, as this will force core to apply every transaction from the beginning of the ledger, which will take an ever increasing amount of time. Instead, we recommend you set the `CATCHUP_RECENT` config value. To do this, determine how long of a downtime you would like to survive (expressed in seconds) and divide by ten.  This roughly equates to the number of ledgers that occur within your desired grace period (ledgers roughly close at a rate of one every ten seconds).  With this value set, core will replay transactions for ledgers that are recent enough, ensuring that the metadata needed by Horizon is present.
 
 ### Correcting gaps in historical data
 
-In the section above, we mentioned that Horizon _tries_ to maintain a gap-free window.  Unfortunately, it cannot directly control the state of stellar-core and [so gaps may form](https://www.stellar.org/developers/software/known-issues.html#gaps-detected) due to extended down time.  When a gap is encountered, Horizon will stop ingesting historical data and complain loudly in the log with error messages (log lines will include "ledger gap detected").  To resolve this situation, you must re-establish the expected state of the stellar-core database and purge historical data from Horizon's database.  We leave the details of this process up to the reader as it is dependent upon your operating needs and configuration, but we offer one potential solution:
+In the section above, we mentioned that Horizon _tries_ to maintain a gap-free window.  Unfortunately, it cannot directly control the state of core and [so gaps may form](https://www.stellar.org/developers/software/known-issues.html#gaps-detected) due to extended down time.  When a gap is encountered, Horizon will stop ingesting historical data and complain loudly in the log with error messages (log lines will include "ledger gap detected").  To resolve this situation, you must re-establish the expected state of the core database and purge historical data from Horizon's database.  We leave the details of this process up to the reader as it is dependent upon your operating needs and configuration, but we offer one potential solution:
 
-We recommend you configure the HISTORY_RETENTION_COUNT in Horizon to a value less than or equal to the configured value for CATCHUP_RECENT in stellar-core.  Given this situation any downtime that would cause a ledger gap will require a downtime greater than the amount of historical data retained by Horizon.  To re-establish continuity:
+We recommend you configure the HISTORY_RETENTION_COUNT in Horizon to a value less than or equal to the configured value for CATCHUP_RECENT in core.  Given this situation any downtime that would cause a ledger gap will require a downtime greater than the amount of historical data retained by Horizon.  To re-establish continuity:
 
 1.  Stop Horizon.
 2.  run `horizon db reap` to clear the historical database.
@@ -130,7 +130,7 @@ We recommend you configure the HISTORY_RETENTION_COUNT in Horizon to a value les
 
 ## Managing Stale Historical Data
 
-Horizon ingests ledger data from a connected instance of stellar-core.  In the event that stellar-core stops running (or if Horizon stops ingesting data for any other reason), the view provided by Horizon will start to lag behind reality.  For simpler applications, this may be fine, but in many cases this lag is unacceptable and the application should not continue operating until the lag is resolved.
+Horizon ingests ledger data from a connected instance of core.  In the event that core stops running (or if Horizon stops ingesting data for any other reason), the view provided by Horizon will start to lag behind reality.  For simpler applications, this may be fine, but in many cases this lag is unacceptable and the application should not continue operating until the lag is resolved.
 
 To help applications that cannot tolerate lag, Horizon provides a configurable "staleness" threshold.  Given that enough lag has accumulated to surpass this threshold (expressed in number of ledgers), Horizon will only respond with an error: [`stale_history`](./errors/stale-history.md).  To configure this option, use either the `--history-stale-threshold` command line flag or the `HISTORY_STALE_THRESHOLD` environment variable.  NOTE:  non-historical requests (such as submitting transactions or finding payment paths) will not error out when the staleness threshold is surpassed.
 
@@ -140,8 +140,4 @@ To ensure that your instance of Horizon is performing correctly we encourage you
 
 Horizon will output logs to standard out.  Information about what requests are coming in will be reported, but more importantly, warnings or errors will also be emitted by default.  A correctly running Horizon instance will not output any warning or error log entries.
 
-Metrics are collected while a Horizon process is running and they are exposed at the `/metrics` path.  You can see an example at (https://horizon-testnet.stellar.org/metrics).
-
-## I'm Stuck! Help!
-
-If any of the above steps don't work or you are otherwise prevented from correctly setting up Horizon, please come to our community and tell us.  Either [post a question at our Stack Exchange](https://stellar.stackexchange.com/) or [chat with us on slack](http://slack.stellar.org/) to ask for help.
+Metrics are collected while a Horizon process is running and they are exposed at the `/metrics` path.  You can see an example at (https://horizon-testnet.kinfederation.com/metrics).

--- a/services/horizon/internal/docs/admin.md
+++ b/services/horizon/internal/docs/admin.md
@@ -9,7 +9,7 @@ This document describes how to administer a **production** Horizon instance. If 
 
 ## Why run Horizon?
 
-The Kin Foundation runs two Horizon servers, one for the public network and one for the test network, free for anyone's use at https://horizon.kinfederation.com and https://horizon-testnet.kinfederation.com .  These servers should be fine for development and small scale projects, but it is not recommended that you use them for production services that need strong reliability.  By running Horizon within your own infrastructure provides a number of benefits:
+The Kin Foundation runs two Horizon servers, one for the public network and one for the test network, free for anyone's use at https://horizon.kinfederation.com and https://horizon-testnet.kininfrastructure.com .  These servers should be fine for development and small scale projects, but it is not recommended that you use them for production services that need strong reliability.  By running Horizon within your own infrastructure provides a number of benefits:
 
   - Multiple instances can be run for redundancy and scalability.
   - Request rate limiting can be disabled.
@@ -140,4 +140,4 @@ To ensure that your instance of Horizon is performing correctly we encourage you
 
 Horizon will output logs to standard out.  Information about what requests are coming in will be reported, but more importantly, warnings or errors will also be emitted by default.  A correctly running Horizon instance will not output any warning or error log entries.
 
-Metrics are collected while a Horizon process is running and they are exposed at the `/metrics` path.  You can see an example at (https://horizon-testnet.kinfederation.com/metrics).
+Metrics are collected while a Horizon process is running and they are exposed at the `/metrics` path.  You can see an example at (https://horizon-testnet.kininfrastructure.com/metrics).

--- a/services/horizon/internal/docs/developing.md
+++ b/services/horizon/internal/docs/developing.md
@@ -85,7 +85,7 @@ Now run your development version of Horizon (which is outside of the container),
 horizon --db-url="postgres://localhost/horizon_dev" --stellar-core-db-url="postgres://stellar:postgres@localhost:8002/core" --stellar-core-url="http://localhost:11626" --port 8001 --network-passphrase "Test SDF Network ; September 2015" --ingest
 ```
 
-If all is well, you should see ingest logs written to standard out. You can test your Horizon instance with a query like: http://localhost:8001/transactions?limit=10&order=asc. Use the [Kin Laboratory](https://kin.org/laboratory/) to craft other queries to try out,
+If all is well, you should see ingest logs written to standard out. You can test your Horizon instance with a query like: http://localhost:8001/transactions?limit=10&order=asc. Use the [Kin Laboratory](https://laboratory.kin.org/) to craft other queries to try out,
 and read about the available endpoints and see examples in the [Horizon API reference](https://www.stellar.org/developers/horizon/reference/).
 
 ## The development cycle

--- a/services/horizon/internal/docs/notes_for_developers.md
+++ b/services/horizon/internal/docs/notes_for_developers.md
@@ -19,19 +19,19 @@ Horizon uses two Go tools you'll need to install:
 1. [go-bindata](https://github.com/jteeuwen/go-bindata) is used to bundle test data
 2. [go-codegen](https://github.com/nullstyle/go-codegen) is used to generate some boilerplate code
 
-After the above are installed, run `go generate github.com/stellar/go/services/horizon/...`. This will look for any `.tmpl` files in the directory and use them to generate code when annotated structs are found in the package source.
+After the above are installed, run `go generate github.com/kinecosystem/go/services/horizon/...`. This will look for any `.tmpl` files in the directory and use them to generate code when annotated structs are found in the package source.
 
 ## <a name="scenarios"></a> Adding, rebuilding and using test scenarios
 
-In order to simulate ledgers Horizon uses [`stellar-core-commander`](https://github.com/stellar/stellar_core_commander) recipe files to add transactions and operations to ledgers using the stellar-core test framework.
+In order to simulate ledgers Horizon uses [`stellar-core-commander`](https://github.com/stellar/stellar_core_commander) recipe files to add transactions and operations to ledgers using the core test framework.
 
 In order to add a new scenario or rebuild existing scenarios you need:
 
 1. [`stellar-core-commander`](https://github.com/stellar/stellar_core_commander) (in short: `scc`) installed and [configured](https://github.com/stellar/stellar_core_commander#assumptions-about-environment).
-2. [`stellar-core`](https://github.com/stellar/stellar-core) binary.
+2. [`core`](https://github.com/kinecosystem/core) binary.
 3. This repository cloned locally.
 
-`scc` allows you to write scripts/recipes that are later executed in `stellar-core` isolated network. After executing a recipe you can then export the `stellar-core` database to be able to run Horizon ingestion system against it (this repository contains a script that does this for you - read below).
+`scc` allows you to write scripts/recipes that are later executed in `core` isolated network. After executing a recipe you can then export the `core` database to be able to run Horizon ingestion system against it (this repository contains a script that does this for you - read below).
 
 ### Example recipe
 
@@ -55,12 +55,12 @@ close_ledger
 payment :scott, :bartek,  [:native, 5]
 ```
 
-You can find more recipes in [`scc` examples](https://github.com/stellar/stellar_core_commander/tree/84d5ffb97202ecc3a0ed34a739c98e69536c0c2c/examples) and [horizon test scenarios](https://github.com/stellar/go/tree/master/services/horizon/internal/test/scenarios).
+You can find more recipes in [`scc` examples](https://github.com/stellar/stellar_core_commander/tree/84d5ffb97202ecc3a0ed34a739c98e69536c0c2c/examples) and [horizon test scenarios](https://github.com/kinecosystem/go/tree/master/services/horizon/internal/test/scenarios).
 
 ### Rebuilding scenarios
 
-1. Create a new or modify existing recipe. All new recipes should be added to [horizon test scenarios](https://github.com/stellar/go/tree/master/services/horizon/internal/test/scenarios) directory.
-2. In `stellar/go` repository root directory run `./services/horizon/internal/scripts/build_test_scenarios.bash`.
+1. Create a new or modify existing recipe. All new recipes should be added to [horizon test scenarios](https://github.com/kinecosystem/go/tree/master/services/horizon/internal/test/scenarios) directory.
+2. In `kinecosystem/go` repository root directory run `./services/horizon/internal/scripts/build_test_scenarios.bash`.
 3. The command above will rebuild all test scenarios. If you need to rebuild only one scenario modify `PACKAGES` environment variable temporarily in the script.
 
 ### Using test scenarios
@@ -91,7 +91,7 @@ start a redis server on port `6379`
 redis-server
 ```
 
-then, run the all the Go monorepo tests like so (assuming you are at stellar/go, or run from stellar/go/services/horizon for just the Horizon subset):
+then, run the all the Go monorepo tests like so (assuming you are at kinecosystem/go, or run from kinecosystem/go/services/horizon for just the Horizon subset):
 
 ```bash
 bash ./support/scripts/run_tests
@@ -100,12 +100,12 @@ bash ./support/scripts/run_tests
 or run individual Horizon tests like so, providing the expected arguments:
 
 ```bash
-go test github.com/stellar/go/services/horizon/...
+go test github.com/kinecosystem/go/services/horizon/...
 ```
 
 ## <a name="logging"></a> Logging
 
-All logging infrastructure is in the `github.com/stellar/go/tree/master/services/horizon/internal/log` package.  This package provides "level-based" logging:  Each logging statement has a severity, one of "Debug", "Info", "Warn", "Error" or "Panic".  The Horizon server has a configured level "filter", specified either using the `--log-level` command line flag or the `LOG_LEVEL` environment variable.  When a logging statement is executed, the statements declared severity is checked against the filter and will only be emitted if the severity of the statement is equal or higher severity than the filter.
+All logging infrastructure is in the `github.com/kinecosystem/go/tree/master/services/horizon/internal/log` package.  This package provides "level-based" logging:  Each logging statement has a severity, one of "Debug", "Info", "Warn", "Error" or "Panic".  The Horizon server has a configured level "filter", specified either using the `--log-level` command line flag or the `LOG_LEVEL` environment variable.  When a logging statement is executed, the statements declared severity is checked against the filter and will only be emitted if the severity of the statement is equal or higher severity than the filter.
 
 In addition, the logging subsystem has support for fields: Arbitrary key-value pairs that will be associated with an entry to allow for filtering and additional contextual information.
 

--- a/services/horizon/internal/docs/readme.md
+++ b/services/horizon/internal/docs/readme.md
@@ -2,22 +2,8 @@
 title: Horizon
 ---
 
-Horizon is the server for the client facing API for the Stellar ecosystem.  It acts as the interface between [stellar-core](https://www.stellar.org/developers/learn/stellar-core) and applications that want to access the Stellar network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams, etc. See [an overview of the Stellar ecosystem](https://www.stellar.org/developers/guides/) for more details.
+Horizon is the server for the client facing API for the Kin ecosystem.  It acts as the interface between [core](https://www.stellar.org/developers/learn/stellar-core) and applications that want to access the Kin network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams, etc.
 
-You can interact directly with horizon via curl or a web browser but SDF provides a [JavaScript SDK](https://www.stellar.org/developers/js-stellar-sdk/learn/) for clients to use to interact with Horizon.
+You can interact directly with Horizon via curl or a web browser but the Kin Foundation provides [SDKs](https://kin.org/developers) for clients to use to interact with Horizon.
 
-SDF runs a instance of Horizon that is connected to the test net [https://horizon-testnet.stellar.org/](https://horizon-testnet.stellar.org/).
-
-## Libraries
-
-SDF maintained libraries:<br />
-- [JavaScript](https://github.com/stellar/js-stellar-sdk)
-- [Java](https://github.com/stellar/java-stellar-sdk)
-- [Go](https://github.com/stellar/go)
-
-Community maintained libraries (in various states of completeness) for interacting with Horizon in other languages:<br>
-- [Ruby](https://github.com/stellar/ruby-stellar-sdk)
-- [Python](https://github.com/StellarCN/py-stellar-base)
-- [C# .NET 2.0](https://github.com/QuantozTechnology/csharp-stellar-base)
-- [C# .NET Core 2.x](https://github.com/elucidsoft/dotnetcore-stellar-sdk)
-- [C++](https://bitbucket.org/bnogal/stellarqore/wiki/Home)
+Kin Foundation runs an instance of Horizon that is connected to the test net [https://horizon-testnet.kinfederation.org/](https://horizon-testnet.kinfederation.org/).

--- a/services/horizon/internal/docs/readme.md
+++ b/services/horizon/internal/docs/readme.md
@@ -4,6 +4,6 @@ title: Horizon
 
 Horizon is the server for the client facing API for the Kin ecosystem.  It acts as the interface between [core](https://www.stellar.org/developers/learn/stellar-core) and applications that want to access the Kin network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams, etc.
 
-You can interact directly with Horizon via curl or a web browser but the Kin Foundation provides [SDKs](https://kin.org/developers) for clients to use to interact with Horizon.
+You can interact directly with Horizon via curl or a web browser but the Kin Foundation provides [SDKs](https://kin.org/developers/) for clients to use to interact with Horizon.
 
-Kin Foundation runs an instance of Horizon that is connected to the test net [https://horizon-testnet.kinfederation.org/](https://horizon-testnet.kinfederation.org/).
+Kin Foundation runs an instance of Horizon that is connected to the test net [https://horizon-testnet.kininfrastructure.org/](https://horizon-testnet.kininfrastructure.org/).

--- a/services/horizon/internal/docs/reference/endpoints/metrics.md
+++ b/services/horizon/internal/docs/reference/endpoints/metrics.md
@@ -13,7 +13,7 @@ GET /metrics
 ### curl Example Request
 
 ```sh
-curl "https://horizon-testnet.stellar.org/metrics"
+curl "https://horizon-testnet.kinfederation.com/metrics"
 ```
 
 
@@ -51,7 +51,7 @@ Horizon utilizes Go's built in concurrency primitives ([goroutines](https://goby
 
 #### History
 
-Horizon maintains its own database (postgres), a verbose and user friendly account of activity on the Stellar network.
+Horizon maintains its own database (postgres), a verbose and user friendly account of activity on the Kin network.
 
 |    Metric     |  Description                                                                                                                               |
 | ---------------- |  ------------------------------------------------------------------------------------------------------------------------------ |
@@ -73,7 +73,7 @@ Horizon maintains its own database (postgres), a verbose and user friendly accou
 ```
 
 #### Ingester
-Ingester represents metrics specific to Horizon's [ingestion](https://github.com/stellar/go/blob/master/services/horizon/internal/docs/reference/admin.md#ingesting-stellar-core-data) process, or the process by which Horizon consumes transaction results from a connected Stellar Core instance.
+Ingester represents metrics specific to Horizon's [ingestion](https://github.com/kinecosystem/go/blob/master/services/horizon/internal/docs/reference/admin.md#ingesting-stellar-core-data) process, or the process by which Horizon consumes transaction results from a connected Core instance.
 
 |    Metric     |  Description                                                                                                                               |
 | ---------------- |  ------------------------------------------------------------------------------------------------------------------------------ |
@@ -214,13 +214,13 @@ These metrics contain useful [sub metrics](#sub-metrics).
 },
 ```
 
-#### Stellar Core
-As noted above, Horizon relies on Stellar Core to stay in sync with the Stellar network. These metrics are specific to the underlying Stellar Core instance.
+#### Core
+As noted above, Horizon relies on Core to stay in sync with the Kin network. These metrics are specific to the underlying Core instance.
 
 |    Metric     |  Description                                                                                                                               |
 | ---------------- |  ------------------------------------------------------------------------------------------------------------------------------ |
-| latest_ledger    | The sequence number of the latest (most recent) ledger recorded in Stellar Core's database.  |
-| open_connections | The number of open connections to the Stellar Core postgres database.  |
+| latest_ledger    | The sequence number of the latest (most recent) ledger recorded in Core's database.  |
+| open_connections | The number of open connections to the Core postgres database.  |
 
 ##### *Example Response:*
 ```shell
@@ -234,13 +234,13 @@ As noted above, Horizon relies on Stellar Core to stay in sync with the Stellar 
 
 #### Transaction Submission
 
-Horizon does not submit transactions directly to the Stellar network. Instead, it sequences transactions and sends the base64 encoded, XDR serialized blob to its connected Stellar Core instance. 
+Horizon does not submit transactions directly to the Kin network. Instead, it sequences transactions and sends the base64 encoded, XDR serialized blob to its connected Core instance. 
 
 ##### Horizon Transaction Sequencing and Submission
 
-The following is a simplified version of the transaction submission process that glosses over the finer details. To dive deeper, check out the [source code](https://github.com/stellar/go/tree/master/services/horizon/internal/txsub).
+The following is a simplified version of the transaction submission process that glosses over the finer details. To dive deeper, check out the [source code](https://github.com/kinecosystem/go/tree/master/services/horizon/internal/txsub).
 
-Horizon's sequencing mechanism consists of a [manager](https://github.com/stellar/go/blob/master/services/horizon/internal/txsub/sequence/manager.go) that keeps track of [submission queues](https://github.com/stellar/go/blob/master/services/horizon/internal/txsub/sequence/queue.go) for a set of addresses. A submission queue is a  priority queue, prioritized by minimum transaction sequence number, that holds a set of pending transactions for an account. A pending transaction is represented as an object with a sequence number and a channel. Periodically, this queue is updated, popping off finished transactions, sending down the transaction's channel a successful/failure response.
+Horizon's sequencing mechanism consists of a [manager](https://github.com/kinecosystem/go/blob/master/services/horizon/internal/txsub/sequence/manager.go) that keeps track of [submission queues](https://github.com/kinecosystem/go/blob/master/services/horizon/internal/txsub/sequence/queue.go) for a set of addresses. A submission queue is a  priority queue, prioritized by minimum transaction sequence number, that holds a set of pending transactions for an account. A pending transaction is represented as an object with a sequence number and a channel. Periodically, this queue is updated, popping off finished transactions, sending down the transaction's channel a successful/failure response.
 
 These metrics contain useful [sub metrics](#sub-metrics).
 

--- a/services/horizon/internal/docs/reference/endpoints/metrics.md
+++ b/services/horizon/internal/docs/reference/endpoints/metrics.md
@@ -13,7 +13,7 @@ GET /metrics
 ### curl Example Request
 
 ```sh
-curl "https://horizon-testnet.kinfederation.com/metrics"
+curl "https://horizon-testnet.kininfrastructure.com/metrics"
 ```
 
 

--- a/services/horizon/internal/docs/reference/errors/server-error.md
+++ b/services/horizon/internal/docs/reference/errors/server-error.md
@@ -8,7 +8,7 @@ Horizon does not expose information such as stack traces or raw error messages t
 
 If you are encountering this error on a server you control, please check the Horizon log files for more details. The logs should contain detailed information to help you discover the root issue.
 
-If you are encountering this error on the public Stellar infrastructure, please report an error on [Horizon's issue tracker](https://github.com/stellar/go/issues) and include the instance attribute.
+If you are encountering this error on the public Kin infrastructure, please report an error on [Horizon's issue tracker](https://github.com/kinecosystem/go/issues) and include the instance attribute.
 Any other information, such as the request that triggered the response, would be most welcome.
 
 ## Attributes

--- a/services/horizon/internal/docs/reference/readme.md
+++ b/services/horizon/internal/docs/reference/readme.md
@@ -9,6 +9,6 @@ Horizon is an API server for the Kin ecosystem.  It acts as the interface betwee
 Horizon provides a RESTful API to allow client applications to interact with the Stellar network. You can communicate with Horizon using cURL or just your web browser. However, if you're building a client application, you'll likely want to use a Stellar SDK in the language of your client.
 Kin Foundation provides [SDKs](https://kin.org/developers) for clients to use to interact with Horizon.
 
-Kin Foundation runs an instance of Horizon that is connected to the test net: [https://horizon-testnet.kinfederation.com/](https://horizon-testnet.kinfederation.com/) and one that is connected to the public Stellar network:
+Kin Foundation runs an instance of Horizon that is connected to the test net: [https://horizon-testnet.kininfrastructure.com/](https://horizon-testnet.kininfrastructure.com/) and one that is connected to the public Stellar network:
 [https://horizon.kinfederation.com/](https://horizon.kinfederation.com/).
 

--- a/services/horizon/internal/docs/reference/readme.md
+++ b/services/horizon/internal/docs/reference/readme.md
@@ -2,24 +2,13 @@
 title: Overview
 ---
 
-Horizon is an API server for the Stellar ecosystem.  It acts as the interface between [stellar-core](https://github.com/stellar/stellar-core) and applications that want to access the Stellar network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams, etc. See [an overview of the Stellar ecosystem](https://www.stellar.org/developers/guides/) for details of where Horizon fits in. You can also watch a [talk on Horizon](https://www.youtube.com/watch?v=AtJ-f6Ih4A4) by Stellar.org developer Scott Fleckenstein:
+Horizon is an API server for the Kin ecosystem.  It acts as the interface between [core](https://github.com/kinecosystem/stellar-core) and applications that want to access the Kin network. It allows you to submit transactions to the network, check the status of accounts, subscribe to event streams, etc. You can also watch a [talk on Horizon](https://www.youtube.com/watch?v=AtJ-f6Ih4A4) by Stellar.org developer Scott Fleckenstein:
 
 [![Horizon: API webserver for the Stellar network](https://img.youtube.com/vi/AtJ-f6Ih4A4/sddefault.jpg "Horizon: API webserver for the Stellar network")](https://www.youtube.com/watch?v=AtJ-f6Ih4A4)
 
 Horizon provides a RESTful API to allow client applications to interact with the Stellar network. You can communicate with Horizon using cURL or just your web browser. However, if you're building a client application, you'll likely want to use a Stellar SDK in the language of your client.
-SDF provides a [JavaScript SDK](https://www.stellar.org/developers/js-stellar-sdk/learn/index.html) for clients to use to interact with Horizon.
+Kin Foundation provides [SDKs](https://kin.org/developers) for clients to use to interact with Horizon.
 
-SDF runs a instance of Horizon that is connected to the test net: [https://horizon-testnet.stellar.org/](https://horizon-testnet.stellar.org/) and one that is connected to the public Stellar network:
-[https://horizon.stellar.org/](https://horizon.stellar.org/).
+Kin Foundation runs an instance of Horizon that is connected to the test net: [https://horizon-testnet.kinfederation.com/](https://horizon-testnet.kinfederation.com/) and one that is connected to the public Stellar network:
+[https://horizon.kinfederation.com/](https://horizon.kinfederation.com/).
 
-## Libraries
-
-SDF maintained libraries:<br />
-- [JavaScript](https://github.com/stellar/js-stellar-sdk)
-- [Java](https://github.com/stellar/java-stellar-sdk)
-- [Go](https://github.com/stellar/go)
-
-Community maintained libraries (in various states of completeness) for interacting with Horizon in other languages:<br>
-- [Ruby](https://github.com/stellar/ruby-stellar-sdk)
-- [Python](https://github.com/StellarCN/py-stellar-base)
-- [C#](https://github.com/elucidsoft/dotnet-stellar-sdk)

--- a/services/horizon/internal/docs/reference/resources/trade.md
+++ b/services/horizon/internal/docs/reference/resources/trade.md
@@ -48,7 +48,7 @@ Price is a precise representation of a bid/ask offer.
 Thus to get price you would take n / d.
 
 #### Synthetic Offer Ids
-Offer ids in the horizon trade resource (base_offer_id, counter_offer_id) are synthetic and don't always reflect the respective stellar-core offer ids. This is due to the fact that stellar-core does not assign offer ids when an offer gets filled immediately. In these cases, Horizon synthetically generates an offer id for the buying offer, based on the total order id of the offer operation. This allows wallets to aggregate historical trades based on offer ids without adding special handling for edge cases. The exact encoding can be found [here](https://github.com/stellar/go/blob/master/services/horizon/internal/db2/history/synt_offer_id.go). 
+Offer ids in the horizon trade resource (base_offer_id, counter_offer_id) are synthetic and don't always reflect the respective core offer ids. This is due to the fact that core does not assign offer ids when an offer gets filled immediately. In these cases, Horizon synthetically generates an offer id for the buying offer, based on the total order id of the offer operation. This allows wallets to aggregate historical trades based on offer ids without adding special handling for edge cases. The exact encoding can be found [here](https://github.com/kinecosystem/go/blob/master/services/horizon/internal/db2/history/synt_offer_id.go). 
 
 ## Links
 

--- a/services/horizon/internal/scripts/build_test_scenarios.bash
+++ b/services/horizon/internal/scripts/build_test_scenarios.bash
@@ -3,10 +3,10 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 GOTOP="$( cd "$DIR/../../../../../../../.." && pwd )"
-PACKAGES=$(find $GOTOP/src/github.com/stellar/go/services/horizon/internal/test/scenarios -iname '*.rb' -not -name '_common_accounts.rb')
-# PACKAGES=$(find $GOTOP/src/github.com/stellar/go/services/horizon/internal/test/scenarios -iname 'kahuna.rb')
+PACKAGES=$(find $GOTOP/src/github.com/kinecosystem/go/services/horizon/internal/test/scenarios -iname '*.rb' -not -name '_common_accounts.rb')
+# PACKAGES=$(find $GOTOP/src/github.com/kinecosystem/go/services/horizon/internal/test/scenarios -iname 'kahuna.rb')
 
-go install github.com/stellar/go/services/horizon
+go install github.com/kinecosystem/go/services/horizon
 
 dropdb hayashi_scenarios --if-exists
 createdb hayashi_scenarios
@@ -45,5 +45,5 @@ done
 
 
 # commit new sql files to bindata
-go generate github.com/stellar/go/services/horizon/internal/test/scenarios
-# go test github.com/stellar/go/services/horizon/internal/ingest
+go generate github.com/kinecosystem/go/services/horizon/internal/test/scenarios
+# go test github.com/kinecosystem/go/services/horizon/internal/ingest

--- a/services/horizon/internal/scripts/rebuild_schema.bash
+++ b/services/horizon/internal/scripts/rebuild_schema.bash
@@ -4,8 +4,8 @@ set -e
 # This scripts rebuilds the latest.sql file included in the schema package.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 GOTOP="$( cd "$DIR/../../../../../../../.." && pwd )"
-go generate github.com/stellar/go/services/horizon/internal/db2/schema
-go install github.com/stellar/go/services/horizon
+go generate github.com/kinecosystem/go/services/horizon/internal/db2/schema
+go install github.com/kinecosystem/go/services/horizon
 dropdb horizon_schema --if-exists
 createdb horizon_schema
 DATABASE_URL=postgres://localhost/horizon_schema?sslmode=disable $GOTOP/bin/horizon db migrate up
@@ -24,6 +24,6 @@ pg_dump postgres://localhost/horizon_schema?sslmode=disable \
   | sed '/SET row_security/d' \
   > $BLANK_PATH
 
-go generate github.com/stellar/go/services/horizon/internal/db2/schema
-go generate github.com/stellar/go/services/horizon/internal/test
-go install github.com/stellar/go/services/horizon
+go generate github.com/kinecosystem/go/services/horizon/internal/db2/schema
+go generate github.com/kinecosystem/go/services/horizon/internal/test
+go install github.com/kinecosystem/go/services/horizon

--- a/tools/stellar-archivist/README.md
+++ b/tools/stellar-archivist/README.md
@@ -14,13 +14,13 @@ It is much smaller and simpler than `stellar-core`, and is intended only for arc
 ## Installation
 
 ```
-$ go install github.com/stellar/go/tools/stellar-archivist
+$ go install github.com/kinecosystem/go/tools/stellar-archivist
 ```
 
 ## Usage
 
 ```
-inspect stellar history archive
+inspect kin history archive
 
 Usage:
   stellar-archivist [flags]

--- a/tools/stellar-sign/README.md
+++ b/tools/stellar-sign/README.md
@@ -9,7 +9,7 @@ This folder contains `stellar-sign` a simple utility to make it easy to add your
 ## Installing
 
 ```bash
-$ go get -u github.com/stellar/go/tools/stellar-sign
+$ go get -u github.com/kinecosystem/go/tools/stellar-sign
 ```
 
 ## Running

--- a/tools/stellar-vanity-gen/README.md
+++ b/tools/stellar-vanity-gen/README.md
@@ -6,7 +6,7 @@ This folder contains `stellar-vanity-gen` a simple utility to generate vanity ad
 ## Installing
 
 ```bash
-$ go get -u github.com/stellar/go/tools/stellar-vanity-gen
+$ go get -u github.com/kinecosystem/go/tools/stellar-vanity-gen
 ```
 
 ## Running


### PR DESCRIPTION
As part of the documentation effort started on kinecosystem/core#21 , I'm fixing references and renaming stellar/go to kinecosystem/go.

Also removed Travis links to stellar org.