### PR TITLE
use strings.Contains() instead of regex.Match() when populating HAL templates

### DIFF
--- a/support/render/hal/link.go
+++ b/support/render/hal/link.go
@@ -1,7 +1,7 @@
 package hal
 
 import (
-	"regexp"
+	"strings"
 )
 
 type Link struct {
@@ -10,11 +10,7 @@ type Link struct {
 }
 
 func (l *Link) PopulateTemplated() {
-	var err error
-	l.Templated, err = regexp.Match("{.*}", []byte(l.Href))
-	if err != nil {
-		panic(err)
-	}
+	l.Templated = strings.Contains(l.Href, "{")
 }
 
 func NewLink(href string) Link {


### PR DESCRIPTION
This improves performances due to less complex string processing. Fixes stellar/go/issues/1446 . Please see the discussion in that issue for more information.