### PR TITLE
all: upgrade logrus to latest release (1.4.2)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -459,14 +459,14 @@
   revision = "83532ca1c1caa393179c677b6facf48e61f4ca5d"
 
 [[projects]]
-  digest = "1:f4144e2638d1a213dc42fc7a7242d48285cbce7ada079f475c96920731b999b0"
+  digest = "1:39553373857c2f3d484b9e1e4474bf6f21a795fe14fe6b941362ee6b266416f3"
   name = "github.com/sirupsen/logrus"
   packages = [
     ".",
     "hooks/test",
   ]
   pruneopts = "T"
-  revision = "68cec9f21fbf3ea8d8f98c044bc6ce05f17b267a"
+  revision = "070c81def33f6362a8267b6a4e56fb7bf23fc6b5"
 
 [[projects]]
   digest = "1:e4ea18b52dd9211e7e7b551ecaef4c49c274b2d9d5df4a46f70a03281a8b3c45"
@@ -639,14 +639,14 @@
   revision = "9bc2a3340c92c17a20edcd0080e93851ed58f5d5"
 
 [[projects]]
-  digest = "1:85c277bcba5f673644793cd86ccca4b366d938e4706c04be7222f6f643a683bb"
+  digest = "1:0e2d0a79d5d135022a0733fa902d8c338871a5112035acd34774f62412b92573"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "T"
-  revision = "1f5e250e1174502017917628cc48b52fdc25b531"
+  revision = "cc5685c2db1239775905f3911f0067c0fa74762f"
 
 [[projects]]
   digest = "1:e75680071853b8e66b993f3b108eac3aa925432a4d2fb0205f6cb6422def925e"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -265,6 +265,14 @@
   version = "v1.1"
 
 [[projects]]
+  digest = "1:31e761d97c76151dde79e9d28964a812c46efc5baee4085b86f68f0c654450de"
+  name = "github.com/konsorten/go-windows-terminal-sequences"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "f55edac94c9bbba5d6182a4be46d86a2c9b5b50e"
+  version = "v1.0.2"
+
+[[projects]]
   digest = "1:045300d96eca8646d57c4a039de9b47694ef328612f69ef0ade22a97a670a8d8"
   name = "github.com/kr/pretty"
   packages = ["."]
@@ -459,14 +467,14 @@
   revision = "83532ca1c1caa393179c677b6facf48e61f4ca5d"
 
 [[projects]]
-  digest = "1:39553373857c2f3d484b9e1e4474bf6f21a795fe14fe6b941362ee6b266416f3"
+  digest = "1:425d221445ea27aaad740ed99e2be7cb463528526e63f6c599ad7d28f7ecea45"
   name = "github.com/sirupsen/logrus"
   packages = [
     ".",
     "hooks/test",
   ]
   pruneopts = "T"
-  revision = "070c81def33f6362a8267b6a4e56fb7bf23fc6b5"
+  revision = "839c75faf7f98a33d445d181f3018b5c3409a45e"
 
 [[projects]]
   digest = "1:e4ea18b52dd9211e7e7b551ecaef4c49c274b2d9d5df4a46f70a03281a8b3c45"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,12 +52,16 @@
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"
-  revision = "68cec9f21fbf3ea8d8f98c044bc6ce05f17b267a"
+  revision = "070c81def33f6362a8267b6a4e56fb7bf23fc6b5"
 
 [[constraint]]
   name = "github.com/throttled/throttled"
   source = "https://github.com/bartekn/throttled.git"
   revision = "c99eef3ad70a3be5a983770523e0e379699c805c"
+
+[[override]]
+  name = "golang.org/x/sys"
+  revision = "cc5685c2db1239775905f3911f0067c0fa74762f"
 
 [prune]
   go-tests = true

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,7 +52,7 @@
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"
-  revision = "070c81def33f6362a8267b6a4e56fb7bf23fc6b5"
+  revision = "839c75faf7f98a33d445d181f3018b5c3409a45e"
 
 [[constraint]]
   name = "github.com/throttled/throttled"

--- a/support/log/entry.go
+++ b/support/log/entry.go
@@ -124,7 +124,7 @@ func (e *Entry) Panic(args ...interface{}) {
 // be recorded (rather than outputted).  The returned function concludes the
 // test, switches the logger back into normal mode and returns a slice of all
 // raw logrus entries that were created during the test.
-func (e *Entry) StartTest(level logrus.Level) func() []*logrus.Entry {
+func (e *Entry) StartTest(level logrus.Level) func() []logrus.Entry {
 	if e.isTesting {
 		panic("cannot start logger test: already testing")
 	}
@@ -140,7 +140,7 @@ func (e *Entry) StartTest(level logrus.Level) func() []*logrus.Entry {
 	oldLevel := e.Logger.Level
 	e.Logger.Level = level
 
-	return func() []*logrus.Entry {
+	return func() []logrus.Entry {
 		e.Logger.Level = oldLevel
 		e.Logger.Out = old
 		e.removeHook(hook)

--- a/support/log/main.go
+++ b/support/log/main.go
@@ -147,7 +147,7 @@ func Panic(args ...interface{}) {
 
 // StartTest shifts the default logger into "test" mode.  See Entry's
 // documentation for the StartTest() method for more info.
-func StartTest(level logrus.Level) func() []*logrus.Entry {
+func StartTest(level logrus.Level) func() []logrus.Entry {
 	return DefaultLogger.StartTest(level)
 }
 


### PR DESCRIPTION
`logrus` changed the type of `Hook.Entries` in May 2018 (https://github.com/sirupsen/logrus/commit/070c81def33f6362a8267b6a4e56fb7bf23fc6b5), so projects using newer versions of `logrus` get incompatible type issues. 

This is currently on a version of `logrus` that's over two years old, so it's probably time to upgrade. Stellar has already done so in stellar/go/pull/927 after the same issue was raised by their community multiple times.